### PR TITLE
Add Clang 19 builds for Almalinux 8 AArch64 and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,22 +37,18 @@ jobs:
         include:
           # Ubuntu
           - os_prefix: ubuntu
-            python_version: 3.6
+            python_version: '3.9'
           - os_prefix: ubuntu
-            python_version: 3.7
+            python_version: '3.10'
           - os_prefix: ubuntu
-            python_version: 3.8
-          - os_prefix: ubuntu
-            python_version: 3.9
+            python_version: '3.11'
           # macOS
           - os_prefix: macos
-            python_version: 3.6
+            python_version: '3.9'
           - os_prefix: macos
-            python_version: 3.7
+            python_version: '3.10'
           - os_prefix: macos
-            python_version: 3.8
-          - os_prefix: macos
-            python_version: 3.9
+            python_version: '3.11'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python_version }}

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     setup(
         name='llvm-installer',
-        version='1.4.9',
+        version='1.4.10',
         url='https://github.com/yugabyte/llvm-installer',
         author='Mikhail Bautin',
         author_email='mbautin@users.noreply.github.com',

--- a/src/llvm_installer/release_tags.json
+++ b/src/llvm_installer/release_tags.json
@@ -5223,6 +5223,20 @@
       "yb_suffix_version": 1
     },
     {
+      "architecture": "aarch64",
+      "is_old_tag_without_os_and_arch": false,
+      "major_version": 19,
+      "minor_version": 1,
+      "patch_version": 0,
+      "sha1_prefix": "a2a6b655",
+      "short_os_name_and_version": "almalinux8",
+      "tag": "v19.1.0-yb-1-1738336307-a2a6b655-almalinux8-aarch64",
+      "timestamp": "1738336307",
+      "version": "19.1.0",
+      "version_suffix": "yb-1",
+      "yb_suffix_version": 1
+    },
+    {
       "architecture": "x86_64",
       "is_old_tag_without_os_and_arch": false,
       "major_version": 19,
@@ -5260,6 +5274,34 @@
       "short_os_name_and_version": "amzn2",
       "tag": "v19.1.0-yb-1-1726864950-a2a6b655-amzn2-x86_64",
       "timestamp": "1726864950",
+      "version": "19.1.0",
+      "version_suffix": "yb-1",
+      "yb_suffix_version": 1
+    },
+    {
+      "architecture": "arm64",
+      "is_old_tag_without_os_and_arch": false,
+      "major_version": 19,
+      "minor_version": 1,
+      "patch_version": 0,
+      "sha1_prefix": "a2a6b655",
+      "short_os_name_and_version": "macos",
+      "tag": "v19.1.0-yb-1-1738381768-a2a6b655-macos-arm64",
+      "timestamp": "1738381768",
+      "version": "19.1.0",
+      "version_suffix": "yb-1",
+      "yb_suffix_version": 1
+    },
+    {
+      "architecture": "x86_64",
+      "is_old_tag_without_os_and_arch": false,
+      "major_version": 19,
+      "minor_version": 1,
+      "patch_version": 0,
+      "sha1_prefix": "a2a6b655",
+      "short_os_name_and_version": "macos",
+      "tag": "v19.1.0-yb-1-1738383009-a2a6b655-macos-x86_64",
+      "timestamp": "1738383009",
       "version": "19.1.0",
       "version_suffix": "yb-1",
       "yb_suffix_version": 1


### PR DESCRIPTION
Also updated list of Python versions we support (3.9-3.11) to remove EOL versions. 3.12+ will require other changes.