### PR TITLE
Fix bin/release_to_pypi.sh

### DIFF
--- a/bin/release_to_pypi.sh
+++ b/bin/release_to_pypi.sh
@@ -12,8 +12,6 @@
 # or implied. See the License for the specific language governing permissions and limitations
 # under the License.
 
-export TWINE_USERNAME=yugabyte
-
 set -euo pipefail -x
 cd "${BASH_SOURCE[0]%/*}"/..
 


### PR DESCRIPTION
Remove the TWINE_USERNAME export as username authentication is no longer allowed, and the instructions in comments for setting up ~/.pypirc uses tokens (but the env variable export will override and cause an error).